### PR TITLE
correct field name accord for struct definition and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,78 @@ This repo contains the templates for `kusion init`, which make it easy to quickl
 
  2. Add template files in the new directory.
 
+ 3. Write a default configuration set file, aka, `kusion.yaml`.
+
 ## Text replacement
 
 Kusion templates use [go template](https://pkg.go.dev/text/template) rules to generate output, which is described in `kusion.yaml`.
 
 `kusion.yaml` contains all configurations, including project level and stack level. 
 
-- `common` represents project level configurations, which can be covered by stack ones.
+- `projectFields` represents project level configurations, which can be covered by stack ones.
 - `stacks` represents stacks level configurations, which is specific to each stack.
+
+Every field type should be one of these two kinds -- one is primitive, anthor is composite. For example:
+- Primitive
+  - string
+  - int
+  - float
+  - bool
+- Composite
+  - array
+  - map
+  - struct
+  - any
+
+All variables defined in template shall have an explaination, for example:
+
+Go template: 
+```go
+name: {{ .Name }}
+age: {{ .Age }}
+gender: {{- if .Sex }} Male {{- else}} Female {{ end }}
+Hobbies: {{ range .Hobbies }}{{"\n"}}- {{.}}{{ end }}
+Additional: {{ range $k, $v := .Additional }}{{"\n"}}  {{ $k }}: {{ $v }}{{ end }}
+```
+
+Field explainations:
+```yaml
+- name: Name
+  type: string
+  default: Tom
+- name: Age
+  type: int
+  default: 8
+- name: Sex
+  type: bool
+  default: true
+- name: Hobbies
+  type: array
+  elem: 
+    type: string 
+  default: 
+    - singing
+    - dancing
+- name: Additional
+  type: map
+  key:
+    type: string
+  value: 
+    type: string
+  default:
+    Country: China
+    Language: Simple Chinese
+```
+
+Output is similar to: 
+```yaml
+name: Tom
+age: 8
+gender: Male
+Hobbies: 
+- dancing
+- singing
+Additional: 
+  Country: China
+  Language: Simple Chinese
+```

--- a/deployment-multi-stack/kusion.yaml
+++ b/deployment-multi-stack/kusion.yaml
@@ -1,7 +1,7 @@
 projectName: my-app
 description: A minimal kusion project of single stack
 quickstart: kusion compile main.k -Y ci-test/settings.yaml
-common:
+projectFields:
   # base/base.k
   - name: ServiceName
     description: service name

--- a/deployment-single-stack/kusion.yaml
+++ b/deployment-single-stack/kusion.yaml
@@ -1,7 +1,7 @@
 projectName: my-app
 description: A minimal kusion project of single stack
 quickstart: kusion compile main.k -Y ci-test/settings.yaml
-common:
+projectFields:
   # base/base.k
   - name: ServiceName
     description: service name


### PR DESCRIPTION
update online template to accord for CLI init scaffold and update README

- change `common` to `projectField`
- add field template description

ref issue: https://github.com/KusionStack/kusion/issues/72
ref PR: https://github.com/KusionStack/kusion/pull/73

